### PR TITLE
Fix being unable to run maintenance wait before db migrations, part 2.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Being unable to run `queue:maintenance:wait` before db migrations, part 2.
 
 ## [3.1.0] - 2017-04-21
 ### Added

--- a/src/Printed/Bundle/Queue/Command/MaintenanceWaitForRunningCommand.php
+++ b/src/Printed/Bundle/Queue/Command/MaintenanceWaitForRunningCommand.php
@@ -2,10 +2,10 @@
 
 namespace Printed\Bundle\Queue\Command;
 
-use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\DriverManager;
 use Printed\Bundle\Queue\EntityInterface\QueueTaskInterface;
 
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DriverManager;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputArgument;


### PR DESCRIPTION
Check for database existence as well.