### PR TITLE
Update the underlying rabbitmq bundle version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Update "php-amqplib/rabbitmq-bundle" dependency. Don't use printedcom's fork anymore.
+  To fix the breaking change, please change:
+```yml
+graceful_max_execution_timeout: 1800
+graceful_max_execution_timeout_exit_code: 10
+```
+to
+```yml
+graceful_max_execution:
+    timeout: 1800
+    exit_code: 10
+```
+in your consumers' configuration for the rabbitmq bundle, if you were using this feature. 
 
 ## [3.2.1] - 2017-05-12
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
 
     "monolog/monolog": "~1.11",
 
-    "php-amqplib/rabbitmq-bundle": "dev-hotfixes",
+    "php-amqplib/rabbitmq-bundle": "^1.13.0",
 
     "ramsey/uuid": "~3.4",
     "php-http/guzzle6-adapter": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -19,13 +19,6 @@
     }
   },
 
-  "repositories": [
-    {
-      "type": "git",
-      "url": "https://github.com/printedcom/RabbitMqBundle.git"
-    }
-  ],
-
   "require": {
     "php": ">=7.0",
 


### PR DESCRIPTION
This ceases the usage of printedcom's fork of that git repository.