### PR TITLE
Update readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,21 +64,19 @@ old_sound_rabbit_mq:
             service_alias:    default_rabbitmq_producer
     
     consumers:
-        upload_picture:
+        upload_picture: &consumer_template
             connection:       default
             queue_options:    { name: 'upload-picture' }
             callback:         upload_picture_service
             qos_options:      { prefetch_size: 0, prefetch_count: 1, global: false }
-            graceful_max_execution_timeout: 1800
-            graceful_max_execution_timeout_exit_code: 10 
+            graceful_max_execution:
+                timeout: 1800
+                exit_code: 10
         
         render_treasure_map:
-            connection:       default
+            <<: *consumer_template
             queue_options:    { name: 'render_treasure_map' }
             callback:         render_treasure_map_service
-            qos_options:      { prefetch_size: 0, prefetch_count: 1, global: false }
-            graceful_max_execution_timeout: 1800
-            graceful_max_execution_timeout_exit_code: 10
 ```
 
 ### Monolog


### PR DESCRIPTION
Update readme to show the current way of configuring the `graceful_max_execution`.

Also, show how duplication of configuration might be prevented with yaml's hashmap merge.